### PR TITLE
Use local timezone instead of UTC

### DIFF
--- a/dot-config/scripts/calendar.sh
+++ b/dot-config/scripts/calendar.sh
@@ -3,7 +3,7 @@
 source "$HOME/.config/scripts/utils.sh"
 
 # Get current time in ISO format
-current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+current_time=$(date +"%Y-%m-%d %H:%M")
 # Get today's date for filtering
 today=$(date +"%Y-%m-%d")
 # Get end of today
@@ -27,7 +27,7 @@ next_event_url=""
 
 for ((i=1; i<${#lines[@]} && events_found<4; i++)); do
   line="${lines[i]}"
-  
+
   # Split the line by tabs
   IFS=$'\t' read -ra event_data <<< "$line"
 
@@ -60,13 +60,13 @@ for ((i=1; i<${#lines[@]} && events_found<4; i++)); do
       if [[ $events_found -eq 0 ]]; then
         next_event_url="$conference_url"
       fi
-      
+
       # Store event information
       event_titles[$events_found]="$title"
       event_times[$events_found]="$start_time"
       event_dates[$events_found]="$start_date"
       event_urls[$events_found]="$conference_url"
-      
+
       events_found=$((events_found + 1))
     fi
   fi
@@ -76,7 +76,7 @@ if [[ $events_found -gt 0 ]]; then
   # Format the first event for the main title
   formatted_time=$(date_from_string "${event_dates[0]} ${event_times[0]}" "+%I:%M %p")
   main_title=$(truncate "${event_titles[0]}" 25)
-  
+
   # Build tooltip with the next 3 events after the first one
   tooltip=""
   if [[ $events_found -gt 1 ]]; then

--- a/dot-config/scripts/utils.sh
+++ b/dot-config/scripts/utils.sh
@@ -1,12 +1,12 @@
 date_from_string() {
   date_string="$1"
   format="${2:-+%s}"
-  
+
   # Try GNU date first (Linux)
   if date -d "$date_string" "$format" 2> /dev/null; then
     return 0
   fi
-  
+
   # For macOS, handle different date string types
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # Try relative time strings (like "15 minutes ago", "1 hour ago", etc.)
@@ -44,7 +44,7 @@ get_end_of_day() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     date -j -f "%Y-%m-%d" "$date_input" "+%Y-%m-%dT23:59:59Z"
   else
-    date -d "$date_input 23:59:59" +"%Y-%m-%dT%H:%M:%SZ"
+    date -d "$date_input 23:59:59" +"%Y-%m-%d %H:%M"
   fi
 }
 


### PR DESCRIPTION
I found that it wasn't showing an event at 5:30 pm on my calendar. Passing in local times to `gcalcli` seemed to work better.

I think this problem was more likely to show up for me because on Pacific time, I'm further away from UTC.