### PR TITLE
Keep VoxType GPU enabled after upgrades

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -321,8 +321,16 @@ install_pacman_hooks() {
   sudo cp "$(dirname "$0")/../hooks/"*.hook /etc/pacman.d/hooks/
 }
 
+setup_voxtype_gpu() {
+  if command -v voxtype >/dev/null 2>&1; then
+    log "Ensuring VoxType GPU acceleration is enabled..."
+    sudo voxtype setup gpu --enable
+  fi
+}
+
 if [ "$(uname)" = "Linux" ]; then
   install_pacman_hooks
+  setup_voxtype_gpu
   allow_fingerprint_usage
   setup_auto_login
   setup_firewall

--- a/hooks/voxtype-gpu.hook
+++ b/hooks/voxtype-gpu.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = voxtype
+
+[Action]
+Description = Re-enabling VoxType GPU acceleration after package change...
+When = PostTransaction
+Exec = /usr/bin/voxtype setup gpu --enable


### PR DESCRIPTION
## Summary
- Add a pacman hook to re-enable VoxType GPU acceleration after install or upgrade
- Run the same GPU setup during Linux dotfiles install when VoxType is present

## Test plan
- [x] bash -n bin/install
- [x] Reviewed pacman hook contents