### PR TITLE
Support parallel explorer subagents

### DIFF
--- a/dot-pi/agent/extensions/explore-subagent.ts
+++ b/dot-pi/agent/extensions/explore-subagent.ts
@@ -11,21 +11,41 @@ const CODEX_EXPLORE_MODEL = "openai-codex/gpt-5.3-codex-spark";
 const FALLBACK_MODEL = CODEX_EXPLORE_MODEL;
 const READ_ONLY_TOOLS = "read,grep,find,ls";
 const MAX_OUTPUT_CHARS = 8_000;
+const MAX_PARALLEL_TASKS = 8;
+const MAX_CONCURRENCY = 4;
+const PARALLEL_PROGRESS_THROTTLE_MS = 1_000;
 
-const exploreSubagentSchema = Type.Object({
+const exploreTaskSchema = Type.Object({
   task: Type.String({
     description:
       "A focused codebase exploration task. Ask for specific files, symbols, flows, or questions to answer. The subagent returns a concise report.",
   }),
   model: Type.Optional(Type.String({
-    description: `Model to use for the exploration subagent. Defaults automatically from the current main model; fallback is ${FALLBACK_MODEL}.`,
+    description: `Model to use for this exploration task. Defaults to the parent/default explore model; fallback is ${FALLBACK_MODEL}.`,
   })),
   cwd: Type.Optional(Type.String({
-    description: "Working directory for the subagent process. Defaults to the current Pi working directory.",
+    description: "Working directory for this subagent process. Defaults to the current Pi working directory.",
   })),
 });
 
-type ExploreSubagentInput = Static<typeof exploreSubagentSchema>;
+const exploreSubagentSchema = Type.Object({
+  task: Type.Optional(Type.String({
+    description:
+      "A focused codebase exploration task for single-subagent mode. Use tasks for parallel mode.",
+  })),
+  tasks: Type.Optional(Type.Array(exploreTaskSchema, {
+    description: `Independent exploration tasks to run in parallel. Limited to ${MAX_PARALLEL_TASKS} tasks, with up to ${MAX_CONCURRENCY} running at once.`,
+    maxItems: MAX_PARALLEL_TASKS,
+  })),
+  model: Type.Optional(Type.String({
+    description: `Model to use for the exploration subagent(s). Defaults automatically from the current main model; fallback is ${FALLBACK_MODEL}.`,
+  })),
+  cwd: Type.Optional(Type.String({
+    description: "Working directory for the subagent process(es). Defaults to the current Pi working directory.",
+  })),
+});
+
+type ExploreSubagentInput = Static<typeof exploreTaskSchema>;
 
 type UsageStats = {
   turns: number;
@@ -289,6 +309,58 @@ function usageLine(usage: UsageStats): string {
   return parts.join(" ");
 }
 
+function emptyUsage(model?: string): UsageStats {
+  return {
+    turns: 0,
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    cost: 0,
+    contextTokens: 0,
+    model,
+  };
+}
+
+function mergeUsage(usages: UsageStats[], fallbackModel?: string): UsageStats {
+  const total = emptyUsage(fallbackModel);
+  for (const usage of usages) {
+    total.turns += usage.turns;
+    total.input += usage.input;
+    total.output += usage.output;
+    total.cacheRead += usage.cacheRead;
+    total.cacheWrite += usage.cacheWrite;
+    total.cost += usage.cost;
+    total.contextTokens = Math.max(total.contextTokens, usage.contextTokens);
+    total.model = total.model === usage.model ? total.model : "multiple";
+  }
+  return total;
+}
+
+function taskPreview(task: string, length = 80): string {
+  const singleLine = task.replace(/\s+/g, " ").trim();
+  return singleLine.length > length ? `${singleLine.slice(0, length)}...` : singleLine;
+}
+
+async function mapWithConcurrencyLimit<T, R>(
+  items: T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
 export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "explore_subagent",
@@ -300,11 +372,129 @@ export default function (pi: ExtensionAPI) {
     promptGuidelines: [
       "Use explore_subagent before implementation when you need to discover files, symbols, architecture, or behavior across a codebase.",
       "Use explore_subagent instead of doing broad read/search loops in the main context; give it a focused task and rely on its concise report.",
+      "For independent codebase questions, pass a tasks array so multiple explorers can run concurrently.",
       "Do not use explore_subagent for edits or commands that need to change files; it is read-only.",
     ],
     parameters: exploreSubagentSchema,
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const model = params.model ?? resolveExploreModel(ctx.model);
+
+      if (params.task && params.tasks?.length) {
+        return {
+          content: [{ type: "text", text: "Invalid parameters. Provide either task for single mode or tasks for parallel mode, not both." }],
+          isError: true,
+        };
+      }
+
+      if (params.tasks?.length) {
+        if (params.tasks.length > MAX_PARALLEL_TASKS) {
+          return {
+            content: [{ type: "text", text: `Too many explore tasks: ${params.tasks.length}. Maximum is ${MAX_PARALLEL_TASKS}.` }],
+            isError: true,
+          };
+        }
+
+        type ParallelResult = Awaited<ReturnType<typeof runExploreSubagent>> & {
+          task: string;
+          index: number;
+        };
+
+        const results: Array<ParallelResult | undefined> = new Array(params.tasks.length);
+        const statuses = params.tasks.map(() => "queued");
+        let lastParallelProgressAt = 0;
+        let pendingParallelProgress: ReturnType<typeof setTimeout> | undefined;
+        const emitParallelProgress = (force = false) => {
+          if (!onUpdate) return;
+
+          const now = Date.now();
+          const elapsed = now - lastParallelProgressAt;
+          const render = () => {
+            if (pendingParallelProgress) clearTimeout(pendingParallelProgress);
+            pendingParallelProgress = undefined;
+            lastParallelProgressAt = Date.now();
+            const done = results.filter(Boolean).length;
+            const running = statuses.filter((status) => status === "running").length;
+            const failed = statuses.filter((status) => status === "failed").length;
+            const queued = statuses.filter((status) => status === "queued").length;
+            onUpdate({
+              content: [{
+                type: "text",
+                text: `Parallel explore: ${done}/${params.tasks!.length} done, ${running} running, ${queued} queued${failed ? `, ${failed} failed` : ""}`,
+              }],
+            });
+          };
+
+          if (force || elapsed >= PARALLEL_PROGRESS_THROTTLE_MS) {
+            render();
+          } else if (!pendingParallelProgress) {
+            pendingParallelProgress = setTimeout(render, PARALLEL_PROGRESS_THROTTLE_MS - elapsed);
+          }
+        };
+        emitParallelProgress(true);
+
+        const completed = await mapWithConcurrencyLimit(params.tasks, MAX_CONCURRENCY, async (task, index) => {
+          const taskModel = task.model ?? model;
+          statuses[index] = "running";
+          emitParallelProgress();
+
+          let result: Awaited<ReturnType<typeof runExploreSubagent>>;
+          try {
+            result = await runExploreSubagent(
+              { task: task.task, model: taskModel, cwd: task.cwd ?? params.cwd },
+              ctx.cwd,
+              signal,
+              () => emitParallelProgress(),
+            );
+          } catch (error) {
+            if (signal?.aborted) throw error;
+            result = {
+              exitCode: 1,
+              output: "(no output)",
+              stderr: error instanceof Error ? error.message : String(error),
+              usage: emptyUsage(taskModel),
+            };
+          }
+
+          const parallelResult = { ...result, task: task.task, index };
+          results[index] = parallelResult;
+          statuses[index] = result.exitCode === 0 ? "done" : "failed";
+          emitParallelProgress(true);
+          return parallelResult;
+        });
+        if (pendingParallelProgress) clearTimeout(pendingParallelProgress);
+        emitParallelProgress(true);
+
+        const successCount = completed.filter((result) => result.exitCode === 0).length;
+        const usage = mergeUsage(completed.map((result) => result.usage), model);
+        const sections = completed.map((result) => {
+          const heading = `## ${result.index + 1}. ${taskPreview(result.task)}`;
+          if (result.exitCode === 0) return `${heading}\n${result.output}`;
+          return `${heading}\nExplore subagent failed with exit code ${result.exitCode}.\n\nSTDERR:\n${result.stderr}\n\nOutput:\n${result.output}`;
+        });
+
+        return {
+          content: [{
+            type: "text",
+            text: `Parallel explore: ${successCount}/${completed.length} succeeded\n\n${sections.join("\n\n")}`,
+          }],
+          details: {
+            mode: "parallel",
+            results: completed,
+            model: usage.model,
+            usage,
+            usageLine: usageLine(usage),
+          },
+          isError: successCount !== completed.length,
+        };
+      }
+
+      if (!params.task) {
+        return {
+          content: [{ type: "text", text: "Invalid parameters. Provide either task for single mode or tasks for parallel mode." }],
+          isError: true,
+        };
+      }
+
       const progressLines = [`Exploring with ${model}...`];
       const emitProgress = (usage?: UsageStats) => {
         const recentLines = progressLines.slice(-12).map((line) => `• ${line}`);
@@ -313,7 +503,7 @@ export default function (pi: ExtensionAPI) {
       };
       emitProgress();
 
-      const result = await runExploreSubagent({ ...params, model }, ctx.cwd, signal, (progress) => {
+      const result = await runExploreSubagent({ task: params.task, model, cwd: params.cwd }, ctx.cwd, signal, (progress) => {
         progressLines.push(progress.text);
         emitProgress(progress.usage);
       });
@@ -333,7 +523,20 @@ export default function (pi: ExtensionAPI) {
       };
     },
     renderCall(args, theme) {
-      const task = args.task ? (args.task.length > 80 ? `${args.task.slice(0, 80)}...` : args.task) : "...";
+      if (args.tasks?.length) {
+        const lines = args.tasks.slice(0, 3).map((task, index) =>
+          `  ${theme.fg("muted", `${index + 1}.`)} ${theme.fg("dim", taskPreview(task.task, 60))}`
+        );
+        if (args.tasks.length > 3) lines.push(`  ${theme.fg("muted", `... +${args.tasks.length - 3} more`)}`);
+        return new Text(
+          `${theme.fg("toolTitle", theme.bold("explore_subagent"))} ${theme.fg("accent", `parallel (${args.tasks.length} tasks)`)} ${theme.fg("muted", args.model ?? "auto")}\n` +
+            lines.join("\n"),
+          0,
+          0,
+        );
+      }
+
+      const task = args.task ? taskPreview(args.task) : "...";
       return new Text(
         `${theme.fg("toolTitle", theme.bold("explore_subagent"))} ${theme.fg("muted", args.model ?? "auto")}\n` +
           `  ${theme.fg("dim", task)}`,


### PR DESCRIPTION
## Summary
- Add a batched `tasks` input to `explore_subagent` for running independent read-only exploration tasks in parallel
- Bound parallel execution with task and concurrency limits, aggregate usage/results, and preserve single-task behavior
- Throttle parallel progress updates to a compact status line to reduce TUI jitter

## Test plan
- [x] `mise exec npm:@earendil-works/pi-coding-agent -- pi -e ./dot-pi/agent/extensions/explore-subagent.ts --help`
- [x] Ran multiple `explore_subagent` calls in parallel from the active Pi session