### PR TITLE
Add llm-usage tmux widget for Claude + Pi token counts

### DIFF
--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -1,4 +1,4 @@
-bin
+^/bin$
 README.md
 ^/CLAUDE.md
 Brewfile

--- a/README.md
+++ b/README.md
@@ -30,3 +30,22 @@ bin/diff: This shows what symlinks are missing.
 bin/ss: Decrypts machine secrets from `~/.config/dotfiles-secrets/secrets.yaml` via `sops` and writes them to `~/.zsh_secrets`. Run on its own to refresh secrets without doing a full install.
 
 bin/migrate-from-1password: One-shot migration that pulls the legacy "ZSH Secrets" 1Password item into the sops-encrypted file. Run once on a GUI-capable machine that's signed into 1Password.
+
+## llm-usage (tmux widget)
+
+`dot-local/bin/llm-usage` aggregates token usage from local Claude Code
+(`~/.claude/projects/*/*.jsonl`) and Pi (`~/.local/state/pi/agent/sessions/**/*.jsonl`)
+session logs and renders a tmux status string showing today's tokens, a trend
+arrow vs. the prior-7-day daily average, and the trailing 7-day total:
+
+    󱙺 8.2M ▲ 446% · 18M/7d
+
+Useful subcommands:
+
+- `llm-usage show` — fast cached render (used by tmux `status-right`).
+- `llm-usage refresh` — synchronous rescan; use on first install.
+- `llm-usage stats` — human-readable breakdown for the last 14 days.
+- `llm-usage reset` — wipe the `~/.cache/llm-usage/` cache.
+
+The collector is incremental (per-file byte offsets in `state.json`), so steady-state
+runs are sub-second.

--- a/dot-config/tmux/tmux.conf
+++ b/dot-config/tmux/tmux.conf
@@ -79,7 +79,7 @@ set-option -g default-command "$SHELL"
 # Status bar with transparent background
 set -g status-style 'bg=default,fg=#cdd6f4'
 set -g status-left-length 20
-set -g status-right-length 80
+set -g status-right-length 120
 set -g status-interval 2
 
 # Window status colors
@@ -97,7 +97,7 @@ set -g message-command-style 'bg=#313244,fg=#cdd6f4'
 
 # Status bar content with transparent sections
 set -g status-left ''
-set -g status-right '#[bg=default]#(developerly status)  #{?client_prefix,#[fg=#f38ba8],#[fg=#45475a]}● #[bg=#45475a,fg=#cdd6f4,bold] #S '
+set -g status-right '#[bg=default]#(llm-usage show)  #(developerly status)  #{?client_prefix,#[fg=#f38ba8],#[fg=#45475a]}● #[bg=#45475a,fg=#cdd6f4,bold] #S '
 
 # Window status format - Enhanced styling with balanced active tab distinction
 set -g window-status-format '#[bg=#181825,fg=#6c7086] #I #[fg=#9399b2]#W#{?window_zoomed_flag,  󰊓,} #[bg=default] '

--- a/dot-local/bin/llm-usage
+++ b/dot-local/bin/llm-usage
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""
+llm-usage — aggregate token usage from Claude Code and Pi session logs.
+
+Data sources (JSONL):
+  - Claude Code: ~/.claude/projects/*/*.jsonl
+      assistant messages have top-level "timestamp" and
+      message.usage.{input_tokens, output_tokens,
+                     cache_creation_input_tokens, cache_read_input_tokens}
+  - Pi:          ~/.local/state/pi/agent/sessions/**/*.jsonl
+      assistant messages have top-level "timestamp" and
+      message.usage.{input, output, cacheRead, cacheWrite, totalTokens, cost.total}
+
+Usage:
+  llm-usage show           # fast: print cached tmux status string;
+                           # forks `collect` to background if cache is stale
+  llm-usage collect        # scan new JSONL bytes, append to events.jsonl,
+                           # re-render display.txt. Safe to run concurrently
+                           # (lockfile).
+  llm-usage refresh        # synchronous collect (use for manual/first run)
+  llm-usage stats          # human-readable breakdown for debugging
+  llm-usage reset          # wipe cache & start over
+
+Cache layout: ~/.cache/llm-usage/
+  state.json     — { paths: { abs_path: byte_offset }, last_collect_ts }
+  events.jsonl   — append-only normalized events:
+                   {ts, tool, model, in, out, cache_r, cache_w, cost}
+  display.txt    — rendered tmux status string
+  collect.lock   — flock guard for `collect`
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import fcntl
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+HOME = Path.home()
+CACHE_DIR = Path(os.environ.get("LLM_USAGE_CACHE_DIR", HOME / ".cache" / "llm-usage"))
+STATE_PATH = CACHE_DIR / "state.json"
+EVENTS_PATH = CACHE_DIR / "events.jsonl"
+DISPLAY_PATH = CACHE_DIR / "display.txt"
+LOCK_PATH = CACHE_DIR / "collect.lock"
+
+# Source globs (paths are evaluated lazily so HOME expansion works).
+CLAUDE_GLOB = HOME / ".claude" / "projects"
+PI_GLOBS = [
+    HOME / ".local" / "state" / "pi" / "agent" / "sessions",
+]
+
+# Refresh `collect` from `show` if the cache is older than this.
+STALE_SECONDS = 60
+
+# tmux status colors (catppuccin / tokyo-night-ish, matching existing config).
+COL_FG_DIM = "#9399b2"
+COL_FG_NEUTRAL = "#6c7086"
+COL_UP = "#f38ba8"      # red — using more than usual
+COL_DOWN = "#a6e3a1"    # green — using less than usual
+COL_RESET = "default"
+
+ICON = os.environ.get("LLM_USAGE_ICON", "󱙺")  # nf-md-robot
+
+# Neutral band: if today is within ±NEUTRAL_PCT of the trailing-7d-avg,
+# show a tilde instead of arrow.
+NEUTRAL_PCT = 10.0
+# If trailing-7d-avg is below this many tokens, suppress trend (not enough data).
+MIN_BASELINE_TOKENS = 100_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def ensure_cache_dir() -> None:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_state() -> dict:
+    if not STATE_PATH.exists():
+        return {"paths": {}, "last_collect_ts": 0}
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except Exception:
+        return {"paths": {}, "last_collect_ts": 0}
+
+
+def save_state(state: dict) -> None:
+    tmp = STATE_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state))
+    tmp.replace(STATE_PATH)
+
+
+def parse_ts(raw: str) -> float | None:
+    """Parse an ISO-8601 timestamp into epoch seconds, or None."""
+    if not raw:
+        return None
+    try:
+        # Python <3.11 needs the trailing Z stripped.
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        return dt.datetime.fromisoformat(raw).timestamp()
+    except Exception:
+        return None
+
+
+def discover_jsonl_files() -> list[tuple[str, Path]]:
+    """Return [(tool, path), ...] for every JSONL we know about."""
+    found: list[tuple[str, Path]] = []
+
+    if CLAUDE_GLOB.is_dir():
+        for p in CLAUDE_GLOB.glob("*/*.jsonl"):
+            if p.is_file():
+                found.append(("claude", p))
+
+    for root in PI_GLOBS:
+        if root.is_dir():
+            for p in root.rglob("*.jsonl"):
+                if p.is_file():
+                    found.append(("pi", p))
+
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Event extraction
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Event:
+    ts: float
+    tool: str
+    model: str
+    inp: int
+    out: int
+    cache_r: int
+    cache_w: int
+    cost: float  # 0 for claude (not in source), provided for pi
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "ts": self.ts,
+                "tool": self.tool,
+                "model": self.model,
+                "in": self.inp,
+                "out": self.out,
+                "cache_r": self.cache_r,
+                "cache_w": self.cache_w,
+                "cost": self.cost,
+            },
+            separators=(",", ":"),
+        )
+
+
+def extract_event(tool: str, line: str) -> Event | None:
+    """Best-effort extraction from one JSONL line. Returns None if not an
+    assistant usage message."""
+    try:
+        d = json.loads(line)
+    except Exception:
+        return None
+
+    if not isinstance(d, dict):
+        return None
+
+    msg = d.get("message")
+    if not isinstance(msg, dict):
+        return None
+    if msg.get("role") != "assistant":
+        return None
+
+    usage = msg.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    ts = parse_ts(d.get("timestamp", ""))
+    if ts is None:
+        return None
+
+    model = msg.get("model") or d.get("modelId") or ""
+
+    if tool == "claude":
+        inp = int(usage.get("input_tokens") or 0)
+        out = int(usage.get("output_tokens") or 0)
+        cache_r = int(usage.get("cache_read_input_tokens") or 0)
+        cache_w = int(usage.get("cache_creation_input_tokens") or 0)
+        cost = 0.0
+    elif tool == "pi":
+        inp = int(usage.get("input") or 0)
+        out = int(usage.get("output") or 0)
+        cache_r = int(usage.get("cacheRead") or 0)
+        cache_w = int(usage.get("cacheWrite") or 0)
+        cost_obj = usage.get("cost") or {}
+        cost = float(cost_obj.get("total") or 0.0)
+    else:
+        return None
+
+    if inp == 0 and out == 0 and cache_r == 0 and cache_w == 0:
+        return None
+
+    return Event(ts, tool, model, inp, out, cache_r, cache_w, cost)
+
+
+# ---------------------------------------------------------------------------
+# Collect
+# ---------------------------------------------------------------------------
+
+
+def acquire_lock(blocking: bool = False) -> int | None:
+    """Acquire the collect lockfile. Returns the fd, or None if non-blocking
+    failed."""
+    ensure_cache_dir()
+    fd = os.open(LOCK_PATH, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        flags = fcntl.LOCK_EX
+        if not blocking:
+            flags |= fcntl.LOCK_NB
+        fcntl.flock(fd, flags)
+        return fd
+    except BlockingIOError:
+        os.close(fd)
+        return None
+
+
+def release_lock(fd: int) -> None:
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def collect(blocking: bool = False) -> bool:
+    """Scan new bytes in known JSONLs, append events, refresh display.
+    Returns True if collection ran, False if another collector held the lock."""
+    ensure_cache_dir()
+
+    fd = acquire_lock(blocking=blocking)
+    if fd is None:
+        return False
+
+    try:
+        state = load_state()
+        offsets: dict[str, int] = state.get("paths", {})
+        files = discover_jsonl_files()
+
+        # Open events file in append mode once.
+        with EVENTS_PATH.open("a", encoding="utf-8") as ev_out:
+            for tool, path in files:
+                key = str(path)
+                try:
+                    size = path.stat().st_size
+                except FileNotFoundError:
+                    continue
+
+                start = offsets.get(key, 0)
+                if start > size:
+                    # File rotated/truncated; start over.
+                    start = 0
+                if start == size:
+                    continue
+
+                try:
+                    with path.open("rb") as f:
+                        f.seek(start)
+                        remaining = f.read()
+                except OSError:
+                    continue
+
+                # Split on newline; keep partial tail unconsumed so next run
+                # picks it up after the writer finishes.
+                last_nl = remaining.rfind(b"\n")
+                if last_nl == -1:
+                    # No complete line yet — leave offset alone.
+                    continue
+                consumed = remaining[: last_nl + 1]
+                new_offset = start + len(consumed)
+
+                for raw in consumed.splitlines():
+                    if not raw.strip():
+                        continue
+                    try:
+                        text = raw.decode("utf-8", errors="replace")
+                    except Exception:
+                        continue
+                    evt = extract_event(tool, text)
+                    if evt is None:
+                        continue
+                    ev_out.write(evt.to_json() + "\n")
+
+                offsets[key] = new_offset
+
+        state["paths"] = offsets
+        state["last_collect_ts"] = time.time()
+        save_state(state)
+
+        render_display()
+        return True
+    finally:
+        release_lock(fd)
+
+
+# ---------------------------------------------------------------------------
+# Aggregation & display
+# ---------------------------------------------------------------------------
+
+
+def iter_events():
+    if not EVENTS_PATH.exists():
+        return
+    with EVENTS_PATH.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except Exception:
+                continue
+
+
+def event_tokens(evt: dict) -> int:
+    """Billable token count — matches Pi's totalTokens convention."""
+    return (
+        int(evt.get("in") or 0)
+        + int(evt.get("out") or 0)
+        + int(evt.get("cache_r") or 0)
+        + int(evt.get("cache_w") or 0)
+    )
+
+
+def fmt_tokens(n: int) -> str:
+    if n < 1_000:
+        return str(n)
+    if n < 10_000:
+        return f"{n / 1_000:.1f}K"
+    if n < 1_000_000:
+        return f"{n // 1_000}K"
+    if n < 10_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n < 1_000_000_000:
+        return f"{n // 1_000_000}M"
+    return f"{n / 1_000_000_000:.1f}B"
+
+
+def aggregate() -> dict:
+    """Bucket events into per-local-date totals, plus a small in-memory total."""
+    now = dt.datetime.now().astimezone()
+    today = now.date()
+    by_date: dict[dt.date, int] = {}
+    total = 0
+    total_events = 0
+    earliest: float | None = None
+    latest: float | None = None
+
+    for evt in iter_events():
+        ts = evt.get("ts")
+        if not isinstance(ts, (int, float)):
+            continue
+        day = dt.datetime.fromtimestamp(ts).astimezone().date()
+        tokens = event_tokens(evt)
+        by_date[day] = by_date.get(day, 0) + tokens
+        total += tokens
+        total_events += 1
+        if earliest is None or ts < earliest:
+            earliest = ts
+        if latest is None or ts > latest:
+            latest = ts
+
+    today_tokens = by_date.get(today, 0)
+
+    # Trailing 7d total = today plus 6 prior days.
+    week_tokens = 0
+    for i in range(7):
+        d = today - dt.timedelta(days=i)
+        week_tokens += by_date.get(d, 0)
+
+    # Baseline = avg of the 7 days *before* today (excludes today).
+    prior_7 = [by_date.get(today - dt.timedelta(days=i), 0) for i in range(1, 8)]
+    baseline = sum(prior_7) / 7.0 if prior_7 else 0.0
+
+    # Trend arrow vs baseline.
+    if baseline < MIN_BASELINE_TOKENS:
+        trend = "neutral"
+        delta_pct = 0.0
+    else:
+        delta_pct = (today_tokens - baseline) / baseline * 100.0
+        if delta_pct > NEUTRAL_PCT:
+            trend = "up"
+        elif delta_pct < -NEUTRAL_PCT:
+            trend = "down"
+        else:
+            trend = "neutral"
+
+    return {
+        "today_tokens": today_tokens,
+        "week_tokens": week_tokens,
+        "baseline": baseline,
+        "trend": trend,
+        "delta_pct": delta_pct,
+        "total_tokens": total,
+        "total_events": total_events,
+        "earliest": earliest,
+        "latest": latest,
+        "by_date": by_date,
+    }
+
+
+def render_tmux(stats: dict) -> str:
+    """Render a tmux-format status string."""
+    today = fmt_tokens(stats["today_tokens"])
+    week = fmt_tokens(stats["week_tokens"])
+    trend = stats["trend"]
+    delta = stats["delta_pct"]
+
+    # tmux's #(...) output is substituted as already-rendered text
+    # (style markers like #[fg=...] still apply, but '%' is literal).
+    if trend == "up":
+        arrow = f"#[fg={COL_UP}]▲ {abs(delta):.0f}%#[fg={COL_RESET}]"
+    elif trend == "down":
+        arrow = f"#[fg={COL_DOWN}]▼ {abs(delta):.0f}%#[fg={COL_RESET}]"
+    else:
+        arrow = f"#[fg={COL_FG_NEUTRAL}]~#[fg={COL_RESET}]"
+
+    # Whole widget in dim fg; arrow colored inline.
+    return (
+        f"#[fg={COL_FG_DIM}]{ICON} {today} {arrow}"
+        f"#[fg={COL_FG_DIM}] · {week}/7d#[fg={COL_RESET}]"
+    )
+
+
+def render_display() -> None:
+    stats = aggregate()
+    text = render_tmux(stats)
+    tmp = DISPLAY_PATH.with_suffix(".txt.tmp")
+    tmp.write_text(text)
+    tmp.replace(DISPLAY_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_show() -> int:
+    ensure_cache_dir()
+    state = load_state()
+    last = float(state.get("last_collect_ts") or 0)
+    age = time.time() - last
+
+    if DISPLAY_PATH.exists():
+        sys.stdout.write(DISPLAY_PATH.read_text())
+    # else: print nothing on first run; collector will populate it.
+
+    if age > STALE_SECONDS:
+        # Fork detached collector so tmux refresh isn't blocked.
+        try:
+            subprocess.Popen(
+                [sys.executable, str(Path(__file__).resolve()), "collect"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except Exception:
+            pass
+
+    return 0
+
+
+def cmd_collect() -> int:
+    collect(blocking=False)
+    return 0
+
+
+def cmd_refresh() -> int:
+    collect(blocking=True)
+    sys.stdout.write(DISPLAY_PATH.read_text() if DISPLAY_PATH.exists() else "")
+    sys.stdout.write("\n")
+    return 0
+
+
+def cmd_stats() -> int:
+    # Make sure we have data; block if needed on first run.
+    state = load_state()
+    if not state.get("last_collect_ts"):
+        sys.stderr.write("first run — collecting events (may take a moment)...\n")
+        collect(blocking=True)
+
+    s = aggregate()
+    today = dt.date.today()
+
+    print(f"events tracked      : {s['total_events']}")
+    print(f"all-time tokens     : {fmt_tokens(s['total_tokens'])}")
+    if s["earliest"]:
+        print(
+            f"date range          : "
+            f"{dt.datetime.fromtimestamp(s['earliest']).date()} "
+            f"→ {dt.datetime.fromtimestamp(s['latest']).date()}"
+        )
+    print()
+    print(f"today  ({today})   : {fmt_tokens(s['today_tokens'])}")
+    print(f"trailing 7d total   : {fmt_tokens(s['week_tokens'])}")
+    print(f"prev 7d daily avg   : {fmt_tokens(int(s['baseline']))}")
+    print(f"trend               : {s['trend']}  ({s['delta_pct']:+.1f}%)")
+    print()
+    print("last 14 days:")
+    for i in range(13, -1, -1):
+        d = today - dt.timedelta(days=i)
+        v = s["by_date"].get(d, 0)
+        bar = "█" * min(40, int(v / max(1, s["baseline"] or 1) * 10)) if v else ""
+        marker = " ←today" if i == 0 else ""
+        print(f"  {d}  {fmt_tokens(v):>8}  {bar}{marker}")
+    print()
+    print(f"tmux render         : {render_tmux(s)}")
+    return 0
+
+
+def cmd_reset() -> int:
+    for p in (STATE_PATH, EVENTS_PATH, DISPLAY_PATH):
+        if p.exists():
+            p.unlink()
+    print(f"cleared {CACHE_DIR}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    cmd = argv[1] if len(argv) > 1 else "show"
+    handlers = {
+        "show": cmd_show,
+        "collect": cmd_collect,
+        "refresh": cmd_refresh,
+        "stats": cmd_stats,
+        "reset": cmd_reset,
+    }
+    fn = handlers.get(cmd)
+    if not fn:
+        sys.stderr.write(f"unknown command: {cmd}\n")
+        sys.stderr.write("usage: llm-usage [show|collect|refresh|stats|reset]\n")
+        return 2
+    return fn()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

- New `dot-local/bin/llm-usage` script that aggregates token usage from local Claude Code (`~/.claude/projects/*/*.jsonl`) and Pi (`~/.local/state/pi/agent/sessions/**/*.jsonl`) session logs into `~/.cache/llm-usage/events.jsonl`, then renders a tmux status string showing today's tokens, a trend arrow vs. the prior 7-day daily average, and the trailing 7-day total — e.g. `󱙺 8.2M ▲ 446% · 18M/7d`. Tokens are normalized to Pi's `totalTokens` convention (input + output + cacheRead + cacheWrite) so both tools are directly comparable.
- Incremental collector with per-file byte offsets in `state.json` (sub-second steady-state runs even with ~100MB of Claude history) and an `flock`-guarded concurrent collect path. `show` is ~50ms (just cats a pre-rendered `display.txt`) and forks a detached `collect` if the cache is older than 60s, so the tmux refresh path never blocks.
- Subcommands: `show` (tmux), `collect` (incremental, non-blocking), `refresh` (synchronous, for first install), `stats` (14-day breakdown for debugging), `reset` (wipe cache).
- Wires `#(llm-usage show)` into `dot-config/tmux/tmux.conf` `status-right` and bumps `status-right-length` 80 → 120 to fit the widget.
- Anchors `.stow-local-ignore`'s `bin` pattern to `^/bin$`. The unanchored form matched any `bin` segment in the tree, which suppressed `dot-local/bin/` (and would suppress any future `dot-*/bin/`) during stow.
- Adds an `## llm-usage (tmux widget)` section to README.

## Test plan

- [x] `llm-usage refresh` — full first-run scan of ~100MB / 16k events completes in ~1.2s
- [x] `llm-usage collect` — incremental no-op run completes in ~120ms
- [x] `llm-usage show` — ~50ms, returns cached display string
- [x] `llm-usage stats` — sane 14-day breakdown, totals match aggregated data
- [x] `stow --simulate` confirms `.local/bin/llm-usage` is now planned (was suppressed by the unanchored `bin` pattern before)
- [x] End-to-end tmux render verified by attaching to a throwaway tmux server with `status-right='#(llm-usage show)'` and capturing the rendered output — `%` survives as literal, `#[fg=...]` markers apply colors correctly
- [ ] After merge: run `bin/install` (or `stow`) in the primary checkout, then `tmux source-file ~/.config/tmux/tmux.conf`