### PR TITLE
Stow shared Developerly config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 dot-zsh/compcache
 /dot-agents/.skill-lock.json
 dot-config/systemd/user/graphical-session.target.wants/
+/dot-config/developerly/credentials.toml
+/dot-config/developerly/projects.toml

--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -11,6 +11,8 @@ Archfile.lock
 .claude
 dot-zsh/compcache
 dot-pi
+^/dot-config/developerly/credentials\.toml$
+^/dot-config/developerly/projects\.toml$
 hooks
 darwin
 docs

--- a/dot-config/developerly/config.toml
+++ b/dot-config/developerly/config.toml
@@ -1,0 +1,39 @@
+# Shared Developerly preferences. Machine-local projects live in
+# ~/.config/developerly/projects.toml; auth lives in credentials.toml.
+status_poll_ms = 750
+pr_poll_ms = 20000
+launcher_kind = "pi"
+launcher_command = ""
+default_planning_mode = false
+theme = "catppuccin-mocha"
+root_session = "developerly"
+root_session_tui = false
+
+[keys]
+assign_epic = ["a"]
+attach = ["enter"]
+attach_worktree = ["w", "shift+enter"]
+changelog = ["C"]
+clear_filter = ["F"]
+delete_task = ["d"]
+edit_task = ["e"]
+filter_assigned_to_me = ["M"]
+filter_epic = ["E"]
+filter_org = ["O"]
+filter_project = ["f"]
+help = ["?"]
+jump_to_root = ["r"]
+nav_down = ["down", "j"]
+nav_up = ["up", "k"]
+new_task = ["n"]
+open_pr = ["o"]
+preview = ["p"]
+projects = ["P"]
+queue_task = ["Q"]
+quit = ["ctrl+q", "q"]
+refresh = ["R"]
+reorder_prefix = ["m"]
+search = ["/"]
+toggle_done = ["space"]
+toggle_done_section = ["D"]
+upgrade = ["u"]


### PR DESCRIPTION
## Summary
- Add shared Developerly preferences to the stowed dotfiles config.
- Keep machine-local Developerly projects and credentials out of the public repo.
- Ignore local Developerly project and credential files if they appear under the stowed path.

## Test plan
- [x] Secret scan of staged Developerly dotfiles config
- [x] `stow -n --verbose=2 --dotfiles --adopt -t "$HOME" .` dry-run for Developerly config