### PR TITLE
Add Omarchy-style screen recording

### DIFF
--- a/Archfile
+++ b/Archfile
@@ -27,6 +27,7 @@ mako
 noto-fonts-emoji
 obsidian
 pipewire
+slurp
 ttf-cascadia-code-nerd
 voxtype
 vulkan-icd-loader
@@ -88,6 +89,7 @@ docker-compose
 dosfstools
 eza
 fd
+ffmpeg
 firewalld
 fwupd
 fzf

--- a/dot-config/hypr/hyprland/binds.conf
+++ b/dot-config/hypr/hyprland/binds.conf
@@ -74,9 +74,10 @@ bind = SHIFT, code:110, exec, hyprshot -m window
 bind = , PRINT, exec, hyprshot -m region
 bind = SHIFT, PRINT, exec, hyprshot -m window
 
-# Screen recording (re-press to stop)
-bind = SUPER SHIFT, R, exec, ~/.config/scripts/record-screen mp4
+# Screen recording (re-press any recording bind to stop)
+bind = SUPER SHIFT, R, exec, ~/.config/scripts/record-screen menu
 bind = SUPER SHIFT, G, exec, ~/.config/scripts/record-screen gif
+bind = SUPER SHIFT, W, exec, ~/.config/scripts/record-screen mp4 --with-desktop-audio --with-microphone-audio --with-webcam
 
 # Special workspaces
 bind = SUPER, S, togglespecialworkspace, magic

--- a/dot-config/hypr/hyprland/windows.conf
+++ b/dot-config/hypr/hyprland/windows.conf
@@ -20,6 +20,13 @@ windowrule = match:class chrome-www.typingmind.com__-Default, workspace special:
 # Basecamp (BSL) Workspace
 windowrule = match:class chrome-3.basecamp.com__5732210-Default, workspace 4
 
+# Webcam overlay for screen recording
+windowrule = match:title WebcamOverlay, float on
+windowrule = match:title WebcamOverlay, pin on
+windowrule = match:title WebcamOverlay, no_initial_focus on
+windowrule = match:title WebcamOverlay, no_dim on
+windowrule = match:title WebcamOverlay, move (monitor_w-window_w-40) (monitor_h-window_h-40)
+
 # Ignore maximize requests from apps. You'll probably like this.
 windowrule = match:class .*, suppress_event maximize
 

--- a/dot-config/scripts/record-screen
+++ b/dot-config/scripts/record-screen
@@ -3,87 +3,507 @@
 # record-screen
 # Toggle screen recording on Hyprland/Wayland.
 #
-# Uses gpu-screen-recorder (DRM/KMS + VAAPI HW encoding) — bypasses both
-# xdg-desktop-portal and the wlr-screencopy capture path that wf-recorder
-# fails on with current Hyprland ("Failed to copy frame" loops).
-# slurp picks the region. On stop, always saves an MP4; optionally also a GIF
-# (rendered through gifski for quality).
+# Omarchy-inspired workflow using gpu-screen-recorder for capture and an
+# ffplay/v4l2 webcam preview window as an overlay. Re-running the command while
+# a recording is active stops it. Supports MP4, optional GIF conversion,
+# desktop/microphone audio, a Walker menu, and a Waybar indicator signal.
 #
 # Usage:
-#   record-screen mp4   # start recording, save MP4 on stop (default)
-#   record-screen gif   # start recording, save MP4 + GIF on stop
-#   record-screen       # same as mp4
+#   record-screen menu
+#   record-screen mp4 [--with-desktop-audio] [--with-microphone-audio] [--with-webcam]
+#   record-screen gif [--with-desktop-audio] [--with-microphone-audio] [--with-webcam]
+#   record-screen --stop
+#   record-screen --status
 #
-# Re-running while a recording is active stops it (regardless of which mode
-# was passed — the mode chosen at start wins).
+# Env:
+#   RECORD_SCREEN_DIR=$HOME/Pictures/Recordings
+#   RECORD_SCREEN_FPS=60
+#   RECORD_SCREEN_USE_PORTAL=true     # use gpu-screen-recorder's portal picker
+#   RECORD_SCREEN_WEBCAM_FILTER=...   # ffmpeg filter for ffplay webcam preview
 
 set -euo pipefail
 
-mode="${1:-mp4}"
-out_dir="$HOME/Pictures/Recordings"
+mode="mp4"
+desktop_audio="false"
+microphone_audio="false"
+webcam="false"
+webcam_device=""
+resolution=""
+show_menu="false"
+stop_requested="false"
+status_requested="false"
+use_portal="${RECORD_SCREEN_USE_PORTAL:-false}"
+fps="${RECORD_SCREEN_FPS:-60}"
+
+out_dir="${RECORD_SCREEN_DIR:-$HOME/Pictures/Recordings}"
 state_dir="${XDG_RUNTIME_DIR:-/tmp}/record-screen"
 pidfile="$state_dir/pid"
 modefile="$state_dir/mode"
 videofile="$state_dir/recording.mp4"
+webcam_pidfile="$state_dir/webcam-pid"
 logfile="$state_dir/log"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  record-screen menu
+  record-screen mp4 [--with-desktop-audio] [--with-microphone-audio] [--with-webcam]
+  record-screen gif [--with-desktop-audio] [--with-microphone-audio] [--with-webcam]
+  record-screen --stop
+  record-screen --status
+
+Options:
+  --with-desktop-audio       Capture default desktop/output audio
+  --with-microphone-audio    Capture default microphone/input audio
+  --with-webcam              Show/capture a webcam overlay window
+  --webcam-device=/dev/videoN
+  --resolution=WxH           Pass output resolution to gpu-screen-recorder
+  --portal                   Use gpu-screen-recorder's portal capture path
+  --stop                     Stop an active recording; exits 1 if idle
+  --status                   Print recording or idle
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        mp4|gif) mode="$arg" ;;
+        menu|--menu) show_menu="true" ;;
+        --with-desktop-audio|--desktop-audio) desktop_audio="true" ;;
+        --with-microphone-audio|--microphone-audio|--mic) microphone_audio="true" ;;
+        --with-webcam|--webcam) webcam="true" ;;
+        --webcam-device=*) webcam_device="${arg#*=}" ;;
+        --resolution=*) resolution="${arg#*=}" ;;
+        --portal) use_portal="true" ;;
+        --stop|stop) stop_requested="true" ;;
+        --status|status) status_requested="true" ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $arg" >&2; usage >&2; exit 2 ;;
+    esac
+done
 
 mkdir -p "$out_dir" "$state_dir"
 
-stop_recording() {
-    local pid saved_mode ts mp4_out gif_out
-    pid="$(cat "$pidfile")"
-    saved_mode="$(cat "$modefile")"
+notify() {
+    notify-send "Screen recording" "$@" 2>/dev/null || true
+}
 
-    kill -SIGINT "$pid" 2>/dev/null || true
-    while kill -0 "$pid" 2>/dev/null; do sleep 0.1; done
+notify_critical() {
+    notify-send -u critical "Screen recording" "$@" 2>/dev/null || true
+}
+
+signal_waybar() {
+    pkill -RTMIN+8 waybar 2>/dev/null || true
+}
+
+recording_active() {
+    [[ -f "$pidfile" ]] || return 1
+    local pid
+    pid="$(cat "$pidfile" 2>/dev/null || true)"
+    [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+list_webcams() {
+    v4l2-ctl --list-devices 2>/dev/null | while IFS= read -r line; do
+        if [[ "$line" != $'\t'* && -n "$line" ]]; then
+            local name="$line"
+            local device=""
+            IFS= read -r device || break
+            device="${device//$'\t'/}"
+            [[ "$device" == /dev/video* ]] && printf '%s  %s\n' "$device" "$name"
+        fi
+    done
+}
+
+choose_from_walker() {
+    local placeholder="$1"
+    if ! command -v walker >/dev/null 2>&1; then
+        notify_critical "Walker is required for the recording menu"
+        return 1
+    fi
+    walker --dmenu --placeholder "$placeholder"
+}
+
+select_webcam_device() {
+    local devices count selection
+    devices="$(list_webcams || true)"
+    count="$(grep -c . <<<"$devices" || true)"
+
+    if [[ -z "$devices" ]] || ((count == 0)); then
+        notify_critical "No webcam devices found"
+        return 1
+    fi
+
+    if ((count == 1)); then
+        awk '{print $1}' <<<"$devices"
+        return 0
+    fi
+
+    selection="$(printf '%s\n' "$devices" | choose_from_walker "Select webcam")" || return 1
+    [[ -n "$selection" ]] || return 1
+    awk '{print $1}' <<<"$selection"
+}
+
+cleanup_webcam() {
+    if [[ -f "$webcam_pidfile" ]]; then
+        local webcam_pid
+        webcam_pid="$(cat "$webcam_pidfile" 2>/dev/null || true)"
+        [[ -n "$webcam_pid" ]] && kill "$webcam_pid" 2>/dev/null || true
+        rm -f "$webcam_pidfile"
+    fi
+
+    # Fallback for stale ffplay windows from older runs.
+    pkill -f "WebcamOverlay" 2>/dev/null || true
+}
+
+start_webcam_overlay() {
+    cleanup_webcam
+
+    if [[ -z "$webcam_device" ]]; then
+        webcam_device="$(select_webcam_device)" || return 1
+    fi
+
+    local scale target_width available_formats video_size_arg webcam_filter
+    scale="$(hyprctl monitors -j 2>/dev/null | jq -r '.[] | select(.focused == true) | .scale' | head -1 || true)"
+    [[ -n "$scale" && "$scale" != "null" ]] || scale="1"
+    target_width="$(awk "BEGIN {printf \"%.0f\", 360 * $scale}")"
+
+    video_size_arg=()
+    available_formats="$(v4l2-ctl --list-formats-ext -d "$webcam_device" 2>/dev/null || true)"
+    for preferred_resolution in 640x360 1280x720 1920x1080; do
+        if grep -q "$preferred_resolution" <<<"$available_formats"; then
+            video_size_arg=(-video_size "$preferred_resolution")
+            break
+        fi
+    done
+
+    # Omarchy-style close-up crop by default. Override to e.g. "scale=360:-1".
+    webcam_filter="${RECORD_SCREEN_WEBCAM_FILTER:-crop=iw/2:ih,scale=${target_width}:-1}"
+
+    ffplay -f v4l2 "${video_size_arg[@]}" -framerate 30 "$webcam_device" \
+        -vf "$webcam_filter" \
+        -window_title "WebcamOverlay" \
+        -noborder \
+        -fflags nobuffer -flags low_delay \
+        -probesize 32 -analyzeduration 0 \
+        -loglevel quiet \
+        </dev/null >>"$logfile" 2>&1 &
+
+    local webcam_pid=$!
+    echo "$webcam_pid" >"$webcam_pidfile"
+    sleep 1
+
+    if ! kill -0 "$webcam_pid" 2>/dev/null; then
+        rm -f "$webcam_pidfile"
+        notify_critical "Webcam overlay failed to start. See $logfile"
+        return 1
+    fi
+}
+
+default_resolution() {
+    local width height
+    read -r width height < <(hyprctl monitors -j 2>/dev/null | jq -r '.[] | select(.focused == true) | "\(.width) \(.height)"' | head -1 || true) || true
+    width="${width:-0}"
+    height="${height:-0}"
+
+    if [[ "$width" =~ ^[0-9]+$ && "$height" =~ ^[0-9]+$ ]] && ((width > 3840 || height > 2160)); then
+        echo "3840x2160"
+    else
+        echo "0x0"
+    fi
+}
+
+# Monitor + window rectangles on the focused workspace, in slurp's "X,Y WxH" format.
+get_rectangles() {
+    local active_workspace
+    active_workspace="$(hyprctl monitors -j 2>/dev/null | jq -r '.[] | select(.focused == true) | .activeWorkspace.id' | head -1 || true)"
+    [[ -n "$active_workspace" && "$active_workspace" != "null" ]] || return 0
+
+    hyprctl monitors -j 2>/dev/null | jq -r --arg ws "$active_workspace" '
+        .[] | select(.activeWorkspace.id == ($ws | tonumber)) |
+        "\(.x),\(.y) \(.width / .scale | floor)x\(.height / .scale | floor)"' || true
+
+    hyprctl clients -j 2>/dev/null | jq -r --arg ws "$active_workspace" '
+        .[] | select(.workspace.id == ($ws | tonumber)) |
+        "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' || true
+}
+
+# Echoes "monitor:NAME" when the selection matches an entire monitor, otherwise
+# "region:WxH+X+Y". Returns non-zero if the user cancelled the picker.
+select_capture_target() {
+    local rects selection sx sy sw sh monitor
+    rects="$(get_rectangles || true)"
+
+    if [[ -n "$rects" ]]; then
+        selection="$(printf '%s\n' "$rects" | slurp 2>/dev/null)" || return 1
+    else
+        selection="$(slurp 2>/dev/null)" || return 1
+    fi
+
+    [[ "$selection" =~ ^(-?[0-9]+),(-?[0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]] || return 1
+    sx=${BASH_REMATCH[1]}
+    sy=${BASH_REMATCH[2]}
+    sw=${BASH_REMATCH[3]}
+    sh=${BASH_REMATCH[4]}
+
+    # A bare click can produce a tiny selection. Snap it to whichever known
+    # monitor/window rectangle the click landed inside.
+    if ((sw * sh < 20)); then
+        while IFS= read -r rect; do
+            [[ "$rect" =~ ^(-?[0-9]+),(-?[0-9]+)[[:space:]]([0-9]+)x([0-9]+)$ ]] || continue
+            local rx=${BASH_REMATCH[1]}
+            local ry=${BASH_REMATCH[2]}
+            local rw=${BASH_REMATCH[3]}
+            local rh=${BASH_REMATCH[4]}
+
+            if ((sx >= rx && sx < rx + rw && sy >= ry && sy < ry + rh)); then
+                sx=$rx
+                sy=$ry
+                sw=$rw
+                sh=$rh
+                break
+            fi
+        done <<<"$rects"
+    fi
+
+    monitor="$(hyprctl monitors -j 2>/dev/null | jq -r --argjson x "$sx" --argjson y "$sy" --argjson w "$sw" --argjson h "$sh" '
+        .[] | select(.x == $x and .y == $y and (.width / .scale | floor) == $w and (.height / .scale | floor) == $h) | .name' | head -1 || true)"
+
+    if [[ -n "$monitor" && "$monitor" != "null" ]]; then
+        echo "monitor:$monitor"
+    else
+        echo "region:${sw}x${sh}+${sx}+${sy}"
+    fi
+}
+
+show_recording_menu() {
+    local choice
+    choice="$({
+        printf 'MP4 · no audio\n'
+        printf 'MP4 · desktop audio\n'
+        printf 'MP4 · desktop + microphone\n'
+        printf 'MP4 · desktop + microphone + webcam\n'
+        printf 'GIF · no audio\n'
+        printf 'GIF · desktop + microphone\n'
+    } | choose_from_walker "Screen recording")" || exit 0
+
+    case "$choice" in
+        "MP4 · no audio")
+            mode="mp4"
+            ;;
+        "MP4 · desktop audio")
+            mode="mp4"
+            desktop_audio="true"
+            ;;
+        "MP4 · desktop + microphone")
+            mode="mp4"
+            desktop_audio="true"
+            microphone_audio="true"
+            ;;
+        "MP4 · desktop + microphone + webcam")
+            mode="mp4"
+            desktop_audio="true"
+            microphone_audio="true"
+            webcam="true"
+            ;;
+        "GIF · no audio")
+            mode="gif"
+            ;;
+        "GIF · desktop + microphone")
+            mode="gif"
+            desktop_audio="true"
+            microphone_audio="true"
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
+}
+
+postprocess_recording() {
+    local file="$1"
+    local processed="${file%.mp4}-processed.mp4"
+    local video_codec=(-c:v copy)
+    local args
+
+    command -v ffmpeg >/dev/null 2>&1 || return 0
+
+    if command -v ffprobe >/dev/null 2>&1 && \
+        ffprobe -v error -select_streams v:0 -read_intervals %+0.2 -show_entries packet=flags -of csv=p=0 "$file" 2>/dev/null | grep -q D; then
+        video_codec=(-c:v libx264 -preset veryfast -crf 20)
+    fi
+
+    args=(-y -ss 0.1 -i "$file" "${video_codec[@]}")
+    if command -v ffprobe >/dev/null 2>&1 && \
+        ffprobe -v error -select_streams a -show_entries stream=codec_type -of csv=p=0 "$file" 2>/dev/null | grep -q audio; then
+        args+=(-af "volume=enable='lt(t,0.4)':volume=0,afade=t=in:st=0.4:d=0.05,loudnorm=I=-14:TP=-1.5:LRA=11")
+    fi
+
+    if ffmpeg "${args[@]}" "$processed" -loglevel quiet 2>/dev/null; then
+        mv "$processed" "$file"
+    else
+        rm -f "$processed"
+    fi
+}
+
+convert_to_gif() {
+    local mp4_out="$1"
+    local gif_out="$2"
+
+    if ! command -v ffmpeg >/dev/null 2>&1 || ! command -v gifski >/dev/null 2>&1; then
+        notify_critical "Cannot convert GIF: ffmpeg and gifski are required"
+        return 1
+    fi
+
+    notify "Converting to GIF..."
+    if ffmpeg -y -i "$mp4_out" -r 15 -f yuv4mpegpipe -pix_fmt yuv420p - 2>/dev/null \
+        | gifski --fps 15 -o "$gif_out" - >/dev/null 2>&1; then
+        return 0
+    fi
+
+    notify_critical "GIF conversion failed"
+    return 1
+}
+
+start_recording() {
+    local capture_args audio_devices audio_args target pid
+
+    rm -f "$videofile" "$logfile" "$pidfile" "$modefile"
+    : >"$logfile"
+
+    if [[ "$webcam" == "true" ]]; then
+        start_webcam_overlay || return 1
+    fi
+
+    if [[ "$use_portal" == "true" ]]; then
+        capture_args=(-w portal -s "${resolution:-$(default_resolution)}")
+        target="portal"
+    else
+        target="$(select_capture_target)" || { cleanup_webcam; notify "Cancelled"; exit 0; }
+
+        case "$target" in
+            monitor:*)
+                capture_args=(-w "${target#monitor:}" -s "${resolution:-$(default_resolution)}")
+                ;;
+            region:*)
+                capture_args=(-w region -region "${target#region:}")
+                [[ -n "$resolution" ]] && capture_args+=(-s "$resolution")
+                ;;
+            *)
+                cleanup_webcam
+                notify_critical "Invalid capture target: $target"
+                exit 1
+                ;;
+        esac
+    fi
+
+    audio_devices=""
+    audio_args=()
+    [[ "$desktop_audio" == "true" ]] && audio_devices="default_output"
+
+    if [[ "$microphone_audio" == "true" ]]; then
+        [[ -n "$audio_devices" ]] && audio_devices+="|"
+        audio_devices+="default_input"
+    fi
+
+    [[ -n "$audio_devices" ]] && audio_args=(-a "$audio_devices" -ac aac)
+
+    echo "===== $(date '+%F %T') mode=$mode webcam=$webcam desktop_audio=$desktop_audio microphone_audio=$microphone_audio target=$target args: $* =====" >>"$logfile"
+
+    setsid gpu-screen-recorder "${capture_args[@]}" \
+        -k auto \
+        -f "$fps" \
+        -fm cfr \
+        -fallback-cpu-encoding yes \
+        -o "$videofile" \
+        "${audio_args[@]}" \
+        </dev/null >>"$logfile" 2>&1 &
+    pid=$!
+    echo "$pid" >"$pidfile"
+    disown "$pid" 2>/dev/null || true
+
+    sleep 0.5
+    if ! kill -0 "$pid" 2>/dev/null; then
+        cleanup_webcam
+        notify_critical "Failed to start. See $logfile"
+        rm -f "$pidfile" "$modefile"
+        exit 1
+    fi
+
+    echo "$mode" >"$modefile"
+    signal_waybar
+    notify "Recording (${mode}) — re-press hotkey or click Waybar icon to stop"
+}
+
+stop_recording() {
+    local pid saved_mode ts mp4_out gif_out count
+    pid="$(cat "$pidfile" 2>/dev/null || true)"
+    saved_mode="$(cat "$modefile" 2>/dev/null || echo mp4)"
+
+    [[ -n "$pid" ]] && kill -SIGINT "$pid" 2>/dev/null || pkill -SIGINT -f "^gpu-screen-recorder" 2>/dev/null || true
+
+    count=0
+    while recording_active && ((count < 50)); do
+        sleep 0.1
+        count=$((count + 1))
+    done
+
+    if recording_active; then
+        [[ -n "$pid" ]] && kill -KILL "$pid" 2>/dev/null || pkill -KILL -f "^gpu-screen-recorder" 2>/dev/null || true
+        notify_critical "Recorder had to be force-killed; video may be corrupted"
+    fi
+
+    cleanup_webcam
     rm -f "$pidfile" "$modefile"
+    signal_waybar
+
+    if [[ ! -f "$videofile" ]]; then
+        notify_critical "No recording file was written. See $logfile"
+        exit 1
+    fi
 
     ts="$(date +%Y%m%d-%H%M%S)"
     mp4_out="$out_dir/recording-$ts.mp4"
     mv "$videofile" "$mp4_out"
 
+    notify "Finalizing..."
+    postprocess_recording "$mp4_out"
+
     if [[ "$saved_mode" == "gif" ]]; then
-        notify-send "Screen recording" "Converting to GIF..."
         gif_out="$out_dir/recording-$ts.gif"
-        # 15fps is plenty for product demos and keeps file size sane
-        ffmpeg -y -i "$mp4_out" -r 15 -f yuv4mpegpipe -pix_fmt yuv420p - 2>/dev/null \
-            | gifski --fps 15 -o "$gif_out" -
-        notify-send "Screen recording" "Saved:\n$mp4_out\n$gif_out"
+        convert_to_gif "$mp4_out" "$gif_out" || true
+        if [[ -f "$gif_out" ]]; then
+            notify "Saved:\n$mp4_out\n$gif_out"
+        else
+            notify "Saved: $mp4_out"
+        fi
     else
-        notify-send "Screen recording" "Saved: $mp4_out"
+        notify "Saved: $mp4_out"
     fi
 }
 
-start_recording() {
-    local region gsr_region pid
-    region="$(slurp)" || { notify-send "Screen recording" "Cancelled"; exit 0; }
-
-    # slurp output: "X,Y WxH"  →  gpu-screen-recorder wants "WxH+X+Y"
-    gsr_region="$(awk '{split($1,xy,","); print $2 "+" xy[1] "+" xy[2]}' <<<"$region")"
-
-    rm -f "$videofile" "$logfile"
-    # setsid detaches from the script's session so the recorder doesn't get
-    # SIGHUP'd when this script exits. The inner shell records its own PID
-    # before exec'ing so we have a stable handle to signal on stop.
-    setsid bash -c "echo \$\$ > '$pidfile'; exec gpu-screen-recorder -w region -region '$gsr_region' -f 30 -o '$videofile'" \
-        </dev/null >"$logfile" 2>&1 &
-    disown
-
-    # Give wf-recorder a moment to actually start; bail loudly if it didn't.
-    sleep 0.4
-    if [[ ! -f "$pidfile" ]] || ! kill -0 "$(cat "$pidfile")" 2>/dev/null; then
-        notify-send -u critical "Screen recording" "wf-recorder failed to start. See $logfile"
-        rm -f "$pidfile" "$modefile"
+if [[ "$status_requested" == "true" ]]; then
+    if recording_active; then
+        echo "recording"
+        exit 0
+    else
+        echo "idle"
         exit 1
     fi
-
-    echo "$mode" > "$modefile"
-    notify-send "Screen recording" "Recording (${mode}) — re-press hotkey to stop"
-}
-
-if [[ -f "$pidfile" ]] && kill -0 "$(cat "$pidfile")" 2>/dev/null; then
-    stop_recording
-else
-    rm -f "$pidfile" "$modefile"
-    start_recording
 fi
+
+if [[ "$stop_requested" == "true" ]]; then
+    recording_active || exit 1
+    stop_recording
+    exit 0
+fi
+
+if recording_active; then
+    stop_recording
+    exit 0
+fi
+
+if [[ "$show_menu" == "true" ]]; then
+    show_recording_menu
+fi
+
+start_recording "$@"

--- a/dot-config/waybar/config.jsonc
+++ b/dot-config/waybar/config.jsonc
@@ -24,6 +24,7 @@
         "power-profiles-daemon",
         "network",
         "custom/voxtype",
+        "custom/screenrecording",
         "battery"
       ]
     },
@@ -50,6 +51,16 @@
       "format": "{}",
       "tooltip": true,
       "on-click": "systemctl --user restart voxtype"
+    },
+    "custom/screenrecording": {
+      "exec": "~/.config/waybar/scripts/screen-recording.sh",
+      "return-type": "json",
+      "format": "{}",
+      "tooltip": true,
+      "hide-empty-text": true,
+      "signal": 8,
+      "interval": 5,
+      "on-click": "~/.config/scripts/record-screen menu"
     },
     "custom/tailscale": {
         "exec": "~/.config/waybar/scripts/tailscale.sh",

--- a/dot-config/waybar/scripts/screen-recording.sh
+++ b/dot-config/waybar/scripts/screen-recording.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+state_dir="${XDG_RUNTIME_DIR:-/tmp}/record-screen"
+pidfile="$state_dir/pid"
+
+if [[ -f "$pidfile" ]] && kill -0 "$(cat "$pidfile" 2>/dev/null)" 2>/dev/null; then
+  printf '{"text":"󰻂","tooltip":"Stop screen recording","class":"active"}\n'
+else
+  printf '{"text":""}\n'
+fi

--- a/dot-config/waybar/style.css
+++ b/dot-config/waybar/style.css
@@ -55,6 +55,16 @@ tooltip {
   padding: 0 6px;
 }
 
+#custom-screenrecording {
+  border-radius: 0;
+  padding: 0 6px;
+  color: #f38ba8;
+}
+
+#custom-screenrecording.active {
+  animation: blink 0.8s linear infinite alternate;
+}
+
 #custom-tailscale {
   border-radius: 10px 0 0 10px;
   padding-right: 6px;
@@ -244,6 +254,7 @@ tooltip {
 #power-profiles-daemon:hover,
 #battery:hover,
 #custom-voxtype:hover,
+#custom-screenrecording:hover,
 #clock:hover {
   background: #45475a;
   transition: all 0.3s ease;
@@ -261,6 +272,7 @@ tooltip {
   border-radius: 0 10px 10px 0;
 }
 
-#custom-voxtype:hover {
+#custom-voxtype:hover,
+#custom-screenrecording:hover {
   border-radius: 0;
 }


### PR DESCRIPTION
## Summary
- expand `record-screen` into an Omarchy-style recording workflow with Walker menu, MP4/GIF modes, desktop/mic audio, webcam overlay, and Waybar updates
- add Hyprland rules/keybinds for pinned webcam capture and quick menu/GIF/webcam recordings
- add a Waybar screen-recording indicator and direct `ffmpeg`/`slurp` package dependencies

## Test plan
- [x] `bash -n dot-config/scripts/record-screen`
- [x] `bash -n dot-config/waybar/scripts/screen-recording.sh`
- [x] parse `dot-config/waybar/config.jsonc` after stripping comments
- [x] `git diff --check`
