### PR TITLE
Use local ssh-agent for server signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Profiles:
 
 - `bin/install` or `bin/install --profile desktop` installs the full workstation setup.
 - `bin/install --profile server` installs shared non-GUI Arch packages and skips desktop setup such as Hyprland, fingerprint auth, TTY auto-login, VoxType/Walker/Elephant hooks, 1Password GUI config, and Hyprshot cleanup.
-- Desktop/macOS profiles run a local fixed-socket `ssh-agent`; server profiles sign commits via forwarded agents from trusted workstations.
+- Desktop/macOS and server profiles run a local fixed-socket `ssh-agent`; Git signing should not rely on SSH agent forwarding.
 - `bin/diff --profile server` dry-runs the server stow overlay.
 
 `Archfile` sections tagged `[desktop]` are skipped by the server profile. Untagged and `[shared]` sections install everywhere. Generated package locks are `Archfile.lock` for desktop and `Archfile.server.lock` for server.

--- a/bin/install
+++ b/bin/install
@@ -509,17 +509,23 @@ setup_ssh_agent_linux() {
     return
   fi
 
+  systemctl --user daemon-reload || true
+
   if ! systemctl --user is-enabled ssh-agent.service >/dev/null 2>&1; then
     log "Enabling ssh-agent user service..."
-    systemctl --user enable --now ssh-agent.service \
+    systemctl --user enable ssh-agent.service \
       || log_error "Could not enable ssh-agent.service."
   fi
+  systemctl --user start ssh-agent.service \
+    || log_error "Could not start ssh-agent.service."
 
   if ! systemctl --user is-enabled ssh-agent-unlock.service >/dev/null 2>&1; then
     log "Enabling ssh-agent-unlock user service..."
-    systemctl --user enable --now ssh-agent-unlock.service \
-      || log_error "Could not enable ssh-agent-unlock.service (is the sops-encrypted key in place?)."
+    systemctl --user enable ssh-agent-unlock.service \
+      || log_error "Could not enable ssh-agent-unlock.service."
   fi
+  systemctl --user restart ssh-agent-unlock.service \
+    || log_error "Could not restart ssh-agent-unlock.service (is the sops-encrypted key in place?)."
 }
 
 setup_ssh_agent_darwin() {
@@ -648,6 +654,7 @@ install_secrets || log_error "Continuing despite secrets install failure; re-run
 if [ "$(uname)" = "Linux" ]; then
   setup_firewall
   setup_syncthing
+  setup_ssh_agent_linux
 
   if is_desktop_profile; then
     install_pacman_hooks
@@ -656,7 +663,6 @@ if [ "$(uname)" = "Linux" ]; then
     allow_fingerprint_usage
     setup_auto_login
     setup_hyprshot_cleanup_cron
-    setup_ssh_agent_linux
   fi
 elif [ "$(uname)" = "Darwin" ]; then
   setup_power_management

--- a/darwin/dot-ssh/config.d/00-agent.conf
+++ b/darwin/dot-ssh/config.d/00-agent.conf
@@ -2,7 +2,6 @@
 # Keep in sync with ~/.zshenv and ~/Library/LaunchAgents/com.trobrock.ssh-agent.plist.
 #
 # This makes ssh use the fixed local agent even from shells/tools that didn't
-# inherit SSH_AUTH_SOCK. Host blocks with ForwardAgent yes will forward this
-# agent to trusted servers.
+# inherit SSH_AUTH_SOCK. ForwardAgent stays opt-in from ~/.ssh/config.local.
 Host *
   IdentityAgent ~/.ssh/agent.sock

--- a/darwin/dot-ssh/config.d/10-agent-forwarding.conf
+++ b/darwin/dot-ssh/config.d/10-agent-forwarding.conf
@@ -1,6 +1,6 @@
 # Managed by dotfiles macOS profile. Stowed to ~/.ssh/config.d/10-agent-forwarding.conf.
-# trobrock-home is the trusted server where remote git signing should use the
-# workstation's local agent. Keep HostName/IP details out of the public repo;
-# add them to ~/.ssh/config.local only if DNS doesn't resolve this alias.
-Host trobrock-home
-  ForwardAgent yes
+# Intentional no-op: repo-managed agent forwarding for git signing was removed.
+# Use the fixed local agent on the machine creating commits instead.
+#
+# If a host still needs forwarding for an exceptional workflow, add that
+# per-host opt-in to ~/.ssh/config.local.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -77,7 +77,7 @@ trobrock-mac:
 
 ## Bootstrapping a new headless machine
 
-1. SSH in (use agent forwarding so the box has GitHub SSH access).
+1. SSH in. If this is a brand-new box with no GitHub access yet, either temporarily use agent forwarding for the initial private secrets clone or copy `~/.config/dotfiles-secrets` from a trusted machine; normal Git signing should not use forwarding after install.
 2. Clone dotfiles: `git clone https://github.com/trobrock/dotfiles ~/dev/personal/dotfiles`
 3. **Seed the age key:**
 
@@ -87,7 +87,7 @@ trobrock-mac:
    chmod 600 ~/.config/sops/age/keys.txt
    ```
 
-4. `cd ~/dev/personal/dotfiles && bin/install`
+4. `cd ~/dev/personal/dotfiles && bin/install --profile server`
 
    The install script will:
    - Install `sops` + `age` via the package manager

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -8,11 +8,11 @@ The current flow uses a single Ed25519 key, stored sops-encrypted in the private
 
 - The private key lives sops-encrypted at `~/.config/dotfiles-secrets/ssh/id_ed25519`.
 - On login, a small script (`~/.config/scripts/ssh-agent-unlock`) decrypts it with sops/age and pipes it straight into `ssh-add -`. The decrypted key never touches disk.
-- Linux: a user systemd unit (`ssh-agent.service`) runs `ssh-agent` on a known socket; a oneshot `ssh-agent-unlock.service` loads the key after it.
+- Linux desktop and server profiles: a user systemd unit (`ssh-agent.service`) runs `ssh-agent` on a known socket; a oneshot `ssh-agent-unlock.service` loads the key after it.
 - macOS: a LaunchAgent (`com.trobrock.ssh-agent`) runs `ssh-agent` on a known socket; `com.trobrock.ssh-agent-unlock` loads the key after it.
-- Git signing uses native `gpg.format = ssh` — no external signer program. The agent serves the key to `ssh-keygen -Y sign` (which is what git invokes internally for SSH-format signatures).
-- Non-server profiles stow a platform-specific `IdentityAgent` config so `ssh` can find the fixed local agent even if a shell/tool didn't inherit `$SSH_AUTH_SOCK`.
-- Headless servers have no key on the box. `ForwardAgent yes` in a trusted host block forwards the workstation agent over the SSH connection; both auth and signing then use your local agent transparently.
+- Git signing uses native `gpg.format = ssh` — no external signer program. The local agent serves the key to `ssh-keygen -Y sign` (which is what git invokes internally for SSH-format signatures).
+- Platform/profile overlays stow an `IdentityAgent` config so `ssh` can find the fixed local agent even if a shell/tool didn't inherit `$SSH_AUTH_SOCK`.
+- Headless servers load their own local agent from the same sops-encrypted key. Repo-managed SSH config does not enable `ForwardAgent`; forwarding is opt-in only from `~/.ssh/config.local` for exceptional cases.
 
 Security boundary: the per-machine age private key at `~/.config/sops/age/keys.txt`. Anyone who can read that file can decrypt the SSH key. Same trust model the rest of the secrets workflow already relies on.
 
@@ -77,32 +77,30 @@ Security boundary: the per-machine age private key at `~/.config/sops/age/keys.t
    git log --show-signature -1   # "Good signature" via allowed_signers
    ```
 
-## Per-host setup for headless servers
+## Headless server setup
 
-On any server you commit from, no key install is needed — just enable agent forwarding from your workstation. The only repo-managed forwarding target today is `trobrock-home`:
+Servers sign locally. The server profile stows the same fixed-socket systemd user units as Linux desktops plus `~/.ssh/config.d/00-agent.conf`, so git signing does not depend on a workstation SSH session or a forwarded agent socket.
 
+On a server:
+
+```sh
+# Seed the age key first if this is a fresh host, then:
+bin/install --profile server
+systemctl --user daemon-reload
+systemctl --user enable --now ssh-agent.service ssh-agent-unlock.service
+ssh-add -l
 ```
-Host trobrock-home
-  ForwardAgent yes
-```
 
-Non-server profiles stow this from `linux/dot-ssh/config.d/10-agent-forwarding.conf` or `darwin/dot-ssh/config.d/10-agent-forwarding.conf`. They also stow `00-agent.conf`, which sets `IdentityAgent` to the fixed local socket. Together, that means `ssh trobrock-home` forwards the workstation agent even from tools or shells that did not inherit `$SSH_AUTH_SOCK`.
+`ssh-add -l` should list the signing key from `~/.config/dotfiles-secrets/ssh/id_ed25519`. If it does not, check that the private secrets repo exists and the server's age key can decrypt it. `~/.ssh/id_ed25519.pub` is optional, but lets the unlock script skip re-adding an already-loaded key.
 
-If a workstation needs private connection details for that alias, add only those details to `~/.ssh/config.local`:
+If a workstation needs private connection details for a server alias, keep only those details in `~/.ssh/config.local`:
 
 ```
 Host trobrock-home
   HostName <private hostname or IP>
 ```
 
-Then `ssh trobrock-home`, and inside that session:
-
-```sh
-ssh-add -l    # should show the forwarded key
-git commit -S -m "test"   # signing works against your forwarded agent
-```
-
-Only enable `ForwardAgent` for hosts you trust. Root on the remote box can use your forwarded agent for the duration of the session.
+Do not add `ForwardAgent yes` for normal git signing. If an exceptional workflow still needs forwarding, opt in per-host from `~/.ssh/config.local` and remember that root on the remote box can talk to your forwarded agent for the duration of the session.
 
 ## Rotating the key
 

--- a/dot-ssh/config
+++ b/dot-ssh/config
@@ -20,14 +20,11 @@ Host *
   ServerAliveInterval 60
   ServerAliveCountMax 3
 
-# -- Agent forwarding for trusted hosts -----------------------------------
+# -- Agent forwarding ------------------------------------------------------
 #
-# ForwardAgent lets a remote box use your local SSH key (for git auth, for
-# `ssh-keygen -Y sign` commit signing, etc.) without ever having the key
-# itself. Only enable this for hosts you fully trust: root on the remote
-# can talk to your forwarded agent for the duration of the session.
+# Dotfiles do not enable ForwardAgent by default. Git signing should use the
+# fixed local agent on the machine creating the commit; forwarding is too
+# fragile for automatic signing and lets the remote host talk to your local
+# agent for the duration of the session.
 #
-# The only repo-managed forwarding target today is trobrock-home, configured
-# by non-server profile overlays in ~/.ssh/config.d. If DNS doesn't resolve the
-# alias on a machine, add only the private HostName/IP detail to
-# ~/.ssh/config.local.
+# If a specific host still needs forwarding, opt in from ~/.ssh/config.local.

--- a/dot-zshenv
+++ b/dot-zshenv
@@ -22,13 +22,16 @@ if [ "${_dotfiles_profile:-desktop}" != "server" ]; then
   export OP_BIOMETRIC_UNLOCK_ENABLED=true
 fi
 
-# Point at the user-managed ssh-agent on Linux desktops. On servers, and
-# inside SSH sessions with agent forwarding, sshd sets SSH_AUTH_SOCK first;
-# the -z guard keeps us from clobbering a forwarded socket.
-if [ "$(uname)" = "Linux" ] \
-   && [ "${_dotfiles_profile:-desktop}" != "server" ] \
-   && [ -z "${SSH_AUTH_SOCK:-}" ]; then
-  export SSH_AUTH_SOCK="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ssh-agent.socket"
+# Point Linux shells at the user-managed fixed-socket ssh-agent. Servers use
+# this local agent for git signing too, so normal commits do not depend on SSH
+# agent forwarding. On server profiles we intentionally prefer the local socket
+# even if sshd provided a forwarded SSH_AUTH_SOCK; desktop profiles keep the
+# old -z guard so explicit inbound forwarding still works.
+if [ "$(uname)" = "Linux" ]; then
+  if [ "${_dotfiles_profile:-desktop}" = "server" ] \
+     || [ -z "${SSH_AUTH_SOCK:-}" ]; then
+    export SSH_AUTH_SOCK="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ssh-agent.socket"
+  fi
 fi
 
 # Same idea on macOS, but Apple's launchd ssh-agent uses a *dynamic* socket

--- a/linux/dot-ssh/config.d/00-agent.conf
+++ b/linux/dot-ssh/config.d/00-agent.conf
@@ -2,7 +2,6 @@
 # Keep in sync with ~/.zshenv and ~/.config/systemd/user/ssh-agent.service.
 #
 # This makes ssh use the fixed local agent even from shells/tools that didn't
-# inherit SSH_AUTH_SOCK. Host blocks with ForwardAgent yes will forward this
-# agent to trusted servers.
+# inherit SSH_AUTH_SOCK. ForwardAgent stays opt-in from ~/.ssh/config.local.
 Host *
   IdentityAgent /run/user/%i/ssh-agent.socket

--- a/linux/dot-ssh/config.d/10-agent-forwarding.conf
+++ b/linux/dot-ssh/config.d/10-agent-forwarding.conf
@@ -1,6 +1,6 @@
 # Managed by dotfiles Linux desktop profile. Stowed to ~/.ssh/config.d/10-agent-forwarding.conf.
-# trobrock-home is the trusted server where remote git signing should use the
-# workstation's local agent. Keep HostName/IP details out of the public repo;
-# add them to ~/.ssh/config.local only if DNS doesn't resolve this alias.
-Host trobrock-home
-  ForwardAgent yes
+# Intentional no-op: repo-managed agent forwarding for git signing was removed.
+# Use the fixed local agent on the machine creating commits instead.
+#
+# If a host still needs forwarding for an exceptional workflow, add that
+# per-host opt-in to ~/.ssh/config.local.

--- a/server/dot-config/local/gitconfig
+++ b/server/dot-config/local/gitconfig
@@ -4,8 +4,8 @@
 [credential "https://gist.github.com"]
 	helper = 
 	helper = !/usr/bin/gh auth git-credential
-# Signing works on servers via agent forwarding: when you SSH in with -A,
-# `ssh-keygen -Y sign` (used internally by git for ssh-format signing) reads
-# the key from your forwarded SSH_AUTH_SOCK. No key needs to live on the box.
+# Signing works on servers via the local fixed-socket ssh-agent managed by
+# ssh-agent.service + ssh-agent-unlock.service. Do not rely on forwarded agents:
+# the unlock service decrypts the sops-encrypted key into the server's agent.
 [commit]
   gpgsign = true

--- a/server/dot-config/systemd/user/ssh-agent-unlock.service
+++ b/server/dot-config/systemd/user/ssh-agent-unlock.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Decrypt and load SSH key into ssh-agent
+Requires=ssh-agent.service
+After=ssh-agent.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+ExecStart=%h/.config/scripts/ssh-agent-unlock
+
+[Install]
+WantedBy=default.target

--- a/server/dot-config/systemd/user/ssh-agent.service
+++ b/server/dot-config/systemd/user/ssh-agent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=SSH key agent
+Documentation=man:ssh-agent(1)
+
+[Service]
+Type=simple
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+# %t expands to $XDG_RUNTIME_DIR (typically /run/user/$UID).
+ExecStart=/usr/bin/ssh-agent -D -a %t/ssh-agent.socket
+
+[Install]
+WantedBy=default.target

--- a/server/dot-ssh/config.d/00-agent.conf
+++ b/server/dot-ssh/config.d/00-agent.conf
@@ -1,0 +1,7 @@
+# Managed by dotfiles server profile. Stowed to ~/.ssh/config.d/00-agent.conf.
+# Keep in sync with ~/.zshenv and ~/.config/systemd/user/ssh-agent.service.
+#
+# Make ssh use the server's fixed local agent for git auth/signing instead of
+# depending on workstation agent forwarding.
+Host *
+  IdentityAgent /run/user/%i/ssh-agent.socket


### PR DESCRIPTION
## Summary
- enable server profile to run a local fixed-socket ssh-agent and unlock the sops-encrypted signing key
- stop relying on repo-managed SSH agent forwarding for git signing
- document local server signing, bootstrap expectations, and forwarding as an exceptional opt-in

## Test plan
- [x] bash -n bin/install dot-config/scripts/ssh-agent-unlock
- [x] git diff --check
- [x] systemd-analyze --user verify linux/dot-config/systemd/user/ssh-agent.service linux/dot-config/systemd/user/ssh-agent-unlock.service server/dot-config/systemd/user/ssh-agent.service server/dot-config/systemd/user/ssh-agent-unlock.service
- [x] stow --simulate --dotfiles --no-folding for ., server/linux/darwin overlays